### PR TITLE
Aproximar función sigmoide a uno o cero

### DIFF
--- a/Back propagation.cpp
+++ b/Back propagation.cpp
@@ -95,7 +95,12 @@ double sigmoide(double  entradas[], int tamanoEntradas, double  pesos[][1], int 
     neto=exp(exponente*(-1));
     result = (1/(1+neto));
 
+    if(result>=0.9)
+        result = 1;
+    else if(result<=0.1)
+        result = 0;
     return result;
+    
 }
 
 


### PR DESCRIPTION
Se aproxima el resultado de la función de transferencia a uno si es mayor que 0.9, a cero si es menor que 0.1, de lo contrario no se aproxima